### PR TITLE
Support paths with and without trailing /

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,5 @@ minima:
   # solarized-dark	   Dark variant of solarized color scheme.
   # solarized	         Adaptive skin for solarized color scheme skins.
   skin: dark
+
+permalink: /:collection/:path/


### PR DESCRIPTION
With this configuration, pages without a trailing `/` redirect to the "correct" URL that includes it.